### PR TITLE
Add setuptools_scm build dep to fix dist-info version not being set

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - twine = twine.__main__:main
@@ -19,12 +19,14 @@ requirements:
   host:
     - pip
     - python >=3.7
+    - setuptools >=45.0
+    - setuptools_scm >=6.0
   run:
     - importlib_metadata >=3.6
     - keyring >=15.1
     - pkginfo >=1.8.1
     - python >=3.7
-    - readme_renderer >=21.0
+    - readme_renderer >=35.0
     - requests >=2.20
     - requests-toolbelt >=0.8.0,!=0.9.0
     - rich >=12.0.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Currently, as first discovered on pypa/twine#902 , the Twine conda package has an empty 0.0.0 version set in the core metadata (`.dist-info`, as displayed by standard Python packaging tooling, e.g. `pip list`, `twine --version`, `importlib_metadata`, etc) instead of the correct version. This is due to a missing `setuptools_scm` build-time dependency; I confirmed that adding such is all that is needed to fix this issue in conda-forge/lektor-feedstock#19 .

Therefore, I've added the required versions of Setuptools and Setuptools_SCM as build-time dependencies (as specified upstream and in the current Setuptools_SCM docs), which should fix the problem (which I'll confirm checking the build output). Additionally, I've bumped the readme_renderer version to match the upstream requirement, which seemed to be an oversight.

I'll re-render once this PR passes tests and I confirm the correct `.dist-info` version is displayed.